### PR TITLE
Remove of convex hull algorithm on create polygon

### DIFF
--- a/src/components/CreateArea/index.js
+++ b/src/components/CreateArea/index.js
@@ -5,14 +5,6 @@ import {useSelector, useDispatch} from 'react-redux';
 import * as selectors from 'store/selectors';
 import * as Actions from 'store/actions';
 import {Point} from './styles';
-import {coordinateToPoint, pointToCoordinate} from '../../geometry/point';
-import {makeHull} from '../../geometry/convexhull';
-
-function ajustCoordinates(coordinates) {
-  const points = coordinates.map(coordinateToPoint);
-  const polygon = makeHull(points);
-  return polygon.map(pointToCoordinate);
-}
 
 const DEFAULT_STATE = {
   coordinates: [],
@@ -25,16 +17,12 @@ const CreateArea = ({show, onPressCreatingArea, reset, index}) => {
   const newAreaRef = useRef(DEFAULT_STATE);
 
   const onPress = (e) => {
-    const coordinates = [
-      ...newAreaRef.current.coordinates,
-      e.nativeEvent.coordinate,
-    ];
-
-    const coordinatesAjusted = ajustCoordinates(coordinates);
-
     const newPoint = {
       ...newAreaRef.current,
-      coordinates: coordinatesAjusted,
+      coordinates: [
+        ...newAreaRef.current.coordinates,
+        e.nativeEvent.coordinate,
+      ],
     };
 
     dispatch(Actions.updateArea(newPoint));


### PR DESCRIPTION
## Motivação
Dado as mudanças dos requisitos acordados na reunião do dia 22 de março, a aplicação do algorítimo para correção da área não é mais uma tarefa prioritária. Antes de realizar algo do tipo será feito um tutorial para a marcação de áreas.

## Mudanças feitas
Esse PR não desfaz todas as mudanças feitas no PR #3, ele apenas tira a função que aplica o algorítimo ao criar um poligono

## Tarefa relacionada

