### PR TITLE
Fixing crash on release version

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -133,6 +133,7 @@ android {
         versionCode 1
         versionName "1.0"
         missingDimensionStrategy 'react-native-camera', 'general'
+        multiDexEnabled true
     }
     splits {
         abi {
@@ -194,7 +195,7 @@ dependencies {
     //noinspection GradleDynamicVersion
     implementation "com.facebook.react:react-native:+"  // From node_modules
     implementation "androidx.swiperefreshlayout:swiperefreshlayout:1.0.0"
-    implementation 'com.facebook.fresco:animated-gif:2.6.0'
+    implementation 'com.facebook.fresco:animated-gif:2.0.0'
 
     compile project(':react-native-vector-icons')
     debugImplementation("com.facebook.flipper:flipper:${FLIPPER_VERSION}") {


### PR DESCRIPTION
## Motivação
The release version of the app was crashing due to a bug in a dependency, which is facebook's fresco animation framework. The debug version worked fine, but when released the app would crash when opened. 

## Mudanças feitas
Changing the version of the library to a stable one.

## Tarefa relacionada

